### PR TITLE
Update __init__.py

### DIFF
--- a/wsgilog/__init__.py
+++ b/wsgilog/__init__.py
@@ -85,6 +85,9 @@ class LogStdout(object):
     def write(self, info):
         '''Writes non-whitespace strings to logger.'''
         if info.lstrip().rstrip() != '': self.logger(info)
+            
+    def flush(self):
+        pass
 
 
 class WsgiLog(object):


### PR DESCRIPTION
Add placeholder flush method to LogStdout.

The standard sys.stdout has a flush method. Some libraries call this method and throw an exception with the message "'LogStdout' object has no attribute 'flush'" when sys.stdout has been replaced with a LogStdout.